### PR TITLE
Median calculation for timers

### DIFF
--- a/src/ledger.cc
+++ b/src/ledger.cc
@@ -150,6 +150,7 @@ void Ledger::process() {
 
       // get count, sum, mean, min, and max
       int count = values.size();
+      int mid = count / 2;
       double min = values.front();
       double max = values.back();
       double sum = 0;
@@ -159,6 +160,13 @@ void Ledger::process() {
         sum += *value_itr;
       }
       double mean = sum / count;
+
+      double median = 0;
+      if (count % 2 == 0) {
+          median = values[mid];
+      } else {
+          median = (values[mid-1] + values[mid]) / 2;
+      }
 
       // initialize sum, mean, and threshold boundary
       double threshold_boundary = max;
@@ -203,6 +211,7 @@ void Ledger::process() {
       current_timer_data["lower"] = min;
       current_timer_data["count"] = this->timer_counters[key];
       current_timer_data["mean"] = mean;
+      current_timer_data["median"] = median;
     }
 
     this->timer_data[key] = current_timer_data;

--- a/src/ledger.cc
+++ b/src/ledger.cc
@@ -163,9 +163,9 @@ void Ledger::process() {
 
       double median = 0;
       if (count % 2 == 0) {
-          median = values[mid];
-      } else {
           median = (values[mid-1] + values[mid]) / 2;
+      } else {
+          median = values[mid];
       }
 
       // initialize sum, mean, and threshold boundary

--- a/test/ledger_test.cc
+++ b/test/ledger_test.cc
@@ -165,6 +165,7 @@ TEST_F(LedgerTest, timer_data) {
   EXPECT_EQ(1, timer_data["timer_data"]["lower"]);
   EXPECT_EQ(10, timer_data["timer_data"]["count"]);
   EXPECT_EQ(5.5, timer_data["timer_data"]["mean"]);
+  EXPECT_EQ(5.5, timer_data["timer_data"]["median"]);
   EXPECT_EQ(9, timer_data["timer_data"]["upper_90"]);
   EXPECT_EQ(9, timer_data["timer_data"]["count_90"]);
   EXPECT_EQ(45, timer_data["timer_data"]["sum_90"]);

--- a/test/ledger_test.cc
+++ b/test/ledger_test.cc
@@ -67,6 +67,7 @@ class LedgerTest: public ::testing::Test {
     // initialize for processing
     ledger.buffer("counter_rate:10000|c");
 
+    // Timer data for general tests
     ledger.buffer("timer_data:1|ms");
     ledger.buffer("timer_data:2|ms");
     ledger.buffer("timer_data:3|ms");
@@ -77,6 +78,17 @@ class LedgerTest: public ::testing::Test {
     ledger.buffer("timer_data:8|ms");
     ledger.buffer("timer_data:9|ms");
     ledger.buffer("timer_data:10|ms");
+
+    // Timer data for median with odd # timers
+    ledger.buffer("timer_data_odd:1|ms");
+    ledger.buffer("timer_data_odd:2|ms");
+    ledger.buffer("timer_data_odd:3|ms");
+    ledger.buffer("timer_data_odd:4|ms");
+    ledger.buffer("timer_data_odd:5|ms");
+    ledger.buffer("timer_data_odd:6|ms");
+    ledger.buffer("timer_data_odd:7|ms");
+    ledger.buffer("timer_data_odd:8|ms");
+    ledger.buffer("timer_data_odd:9|ms");
 
     ledger.process();
 
@@ -170,6 +182,10 @@ TEST_F(LedgerTest, timer_data) {
   EXPECT_EQ(9, timer_data["timer_data"]["count_90"]);
   EXPECT_EQ(45, timer_data["timer_data"]["sum_90"]);
   EXPECT_EQ(5, timer_data["timer_data"]["mean_90"]);
+}
+
+TEST_F(LedgerTest, timer_data_odd) {
+  EXPECT_EQ(5, timer_data["timer_data_odd"]["median"]);
 }
 
 }  // namespace statsdcc


### PR DESCRIPTION
The median operation was not re-implemented during the statsd compatibility work that was done.  This is to add that functionality into the product.

This is a re-implementation of https://github.com/etsy/statsd/blob/master/lib/process_metrics.js#L90-L91