### PR TITLE
Raw Repeater

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,6 @@ Example configuration files are in [statsdcc/etc](Logger)
 
 -	`repeaters`: Using repeaters you can flush the aggregates to another statsdcc-aggregator or statsdcc-proxy.
 
-	`repeater_raw`: When using a repeater should raw metrics be send instead of aggregates.  Defaults to false.
 	```
 	"repeaters": [
 		{
@@ -143,6 +142,10 @@ Example configuration files are in [statsdcc/etc](Logger)
 		}
 	]
 	```
+-   `repeater_raw`: When using a repeater should raw metrics be send instead of aggregates.  Defaults to false.
+	```
+    "repeater_raw": false
+    ```
 
 ### Proxy Configuration Variables
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Example configuration files are in [statsdcc/etc](Logger)
 
 -	`repeaters`: Using repeaters you can flush the aggregates to another statsdcc-aggregator or statsdcc-proxy.
 
+	`repeater_raw`: When using a repeater should raw metrics be send instead of aggregates.  Defaults to false.
 	```
 	"repeaters": [
 		{

--- a/include/statsdcc/backends/repeater.h
+++ b/include/statsdcc/backends/repeater.h
@@ -41,7 +41,6 @@ class Repeater: public statsdcc::backends::Backend {
  private:
   inline void send(std::string metric) {
     for (unsigned int i = 0; i < this->destinations.size(); ++i) {
-      metric = metric.substr(0, metric.size()-1);
       net::wrapper::sendto(this->sockfd,
         static_cast<const void*>(metric.c_str()),
         metric.length(),

--- a/include/statsdcc/configs/aggregator_config.h
+++ b/include/statsdcc/configs/aggregator_config.h
@@ -33,7 +33,7 @@ class AggregatorConfig : public Config {
 
   std::string prefix;
 
-  std::string repeater_raw;
+  bool repeater_raw;
 
   int frequency;       // default: 10
 

--- a/include/statsdcc/configs/aggregator_config.h
+++ b/include/statsdcc/configs/aggregator_config.h
@@ -33,6 +33,8 @@ class AggregatorConfig : public Config {
 
   std::string prefix;
 
+  std::string repeater_raw;
+
   int frequency;       // default: 10
 
   std::vector<int> percentiles;  // default: [90]

--- a/lib/backends/repeater.cc
+++ b/lib/backends/repeater.cc
@@ -73,8 +73,8 @@ void Repeater::flush_stats(const Ledger& ledger, int flusher_id) {
 
   // timers
   if (config->repeater_raw) {
-    for (timer_key_value_pair_itr = this->timers.cbegin();
-         timer_key_value_pair_itr != this->timers.cend();
+    for (auto timer_key_value_pair_itr = ledger.timers.cbegin();
+         timer_key_value_pair_itr != ledger.timers.cend();
          ++timer_key_value_pair_itr) {
       std::string key = timer_key_value_pair_itr->first;
       if (key.length() > 0) {
@@ -82,7 +82,8 @@ void Repeater::flush_stats(const Ledger& ledger, int flusher_id) {
         for (auto value_itr = values.cbegin();
           value_itr != values.cend();
           ++value_itr) {
-          out += key + ":" + *value_itr + "|ms\n";
+          std::string value = std::to_string(static_cast<long double>(value_itr));
+          out += key + ":" + value + "|ms\n";
         }
         this->send(out);
       }

--- a/lib/backends/repeater.cc
+++ b/lib/backends/repeater.cc
@@ -59,7 +59,7 @@ void Repeater::flush_stats(const Ledger& ledger, int flusher_id) {
     std::string value =
       std::to_string(static_cast<long double>(counter_itr->second));
 
-    if (config->repeater_raw) {
+    if (::config->repeater_raw) {
       this->send(key + ":" + value + "|c");
     } else {
       std::string value_per_second =
@@ -72,7 +72,7 @@ void Repeater::flush_stats(const Ledger& ledger, int flusher_id) {
   }
 
   // timers
-  if (config->repeater_raw) {
+  if (::config->repeater_raw) {
     for (auto timer_key_value_pair_itr = ledger.timers.cbegin();
          timer_key_value_pair_itr != ledger.timers.cend();
          ++timer_key_value_pair_itr) {

--- a/lib/backends/repeater.cc
+++ b/lib/backends/repeater.cc
@@ -77,12 +77,13 @@ void Repeater::flush_stats(const Ledger& ledger, int flusher_id) {
          timer_key_value_pair_itr != ledger.timers.cend();
          ++timer_key_value_pair_itr) {
       std::string key = timer_key_value_pair_itr->first;
+      std::string out = "";
       if (key.length() > 0) {
         std::vector<double> values(timer_key_value_pair_itr->second);
         for (auto value_itr = values.cbegin();
           value_itr != values.cend();
           ++value_itr) {
-          std::string value = std::to_string(static_cast<long double>(value_itr));
+          std::string value = std::to_string(static_cast<long double>(*value_itr));
           out += key + ":" + value + "|ms\n";
         }
         this->send(out);

--- a/lib/backends/repeater.cc
+++ b/lib/backends/repeater.cc
@@ -59,33 +59,54 @@ void Repeater::flush_stats(const Ledger& ledger, int flusher_id) {
     std::string value =
       std::to_string(static_cast<long double>(counter_itr->second));
 
-    std::string value_per_second =
-      std::to_string(static_cast<long double>(ledger.counter_rates.at(key)));
+    if (config->repeater_raw) {
+      this->send(key + ":" + value + "|c");
+    } else {
+      std::string value_per_second =
+        std::to_string(static_cast<long double>(ledger.counter_rates.at(key)));
 
-    this->send(key + ".rate:" + value_per_second + "|c\n" +
-               key + ".count:" + value + "|c");
+      this->send(key + ".rate:" + value_per_second + "|c\n" +
+                 key + ".count:" + value + "|c");
+    }
 
   }
 
   // timers
-  for (auto timer_itr = ledger.timer_data.cbegin();
-      timer_itr != ledger.timer_data.cend();
-      ++timer_itr) {
-    std::string key = timer_itr->first;
-    std::string out = "";
-
-    for (auto timer_data_itr = timer_itr->second.cbegin();
-        timer_data_itr != timer_itr->second.cend();
-        ++timer_data_itr) {
-      std::string timer_data_key = timer_data_itr->first;
-
-      std::string value = std::to_string(
-        static_cast<long double>(timer_data_itr->second));
-
-      out += key + "." + timer_data_key + ":" + value + "|ms";
+  if (config->repeater_raw) {
+    for (timer_key_value_pair_itr = this->timers.cbegin();
+         timer_key_value_pair_itr != this->timers.cend();
+         ++timer_key_value_pair_itr) {
+      std::string key = timer_key_value_pair_itr->first;
+      if (key.length() > 0) {
+        std::vector<double> values(timer_key_value_pair_itr->second);
+        for (auto value_itr = values.cbegin();
+          value_itr != values.cend();
+          ++value_itr) {
+          out += key + ":" + *value_itr + "|ms\n";
+        }
+        this->send(out);
+      }
     }
-    out.erase(out.end() - 1);
-    this->send(out);
+  } else {
+    for (auto timer_itr = ledger.timer_data.cbegin();
+        timer_itr != ledger.timer_data.cend();
+        ++timer_itr) {
+      std::string key = timer_itr->first;
+      std::string out = "";
+
+      for (auto timer_data_itr = timer_itr->second.cbegin();
+          timer_data_itr != timer_itr->second.cend();
+          ++timer_data_itr) {
+        std::string timer_data_key = timer_data_itr->first;
+
+        std::string value = std::to_string(
+          static_cast<long double>(timer_data_itr->second));
+
+        out += key + "." + timer_data_key + ":" + value + "|ms";
+      }
+      out.erase(out.end() - 1);
+      this->send(out);
+    }
   }
 
   // gauges

--- a/src/configs/aggregator_config.cc
+++ b/src/configs/aggregator_config.cc
@@ -16,7 +16,7 @@ AggregatorConfig::AggregatorConfig(const Json::Value& json)
   }
 
   this->frequency = json.get("frequency", 10).asInt();
-  this->repeater_raw = json.get("repeater_raw", false);
+  this->repeater_raw = json.get("repeater_raw", false).asBool();
 
   Json::Value ps = json["percentiles"];
   if (ps.size() == 0) {

--- a/src/configs/aggregator_config.cc
+++ b/src/configs/aggregator_config.cc
@@ -16,6 +16,7 @@ AggregatorConfig::AggregatorConfig(const Json::Value& json)
   }
 
   this->frequency = json.get("frequency", 10).asInt();
+  this->repeater_raw = json.get("repeater_raw", false);
 
   Json::Value ps = json["percentiles"];
   if (ps.size() == 0) {


### PR DESCRIPTION
The default design for statsdcc is when using the "repeater" functionality it will send the aggregated metrics to another statsdcc instance for further calculation/forwarding.  This causes an inherent double aggregation of the raw metrics for counters and timers.  Once at each level of statsdcc.  This PR will add a switch to the product that will instead relay "raw" metrics to the next level.  