### PR TITLE
Repeater Timers

### DIFF
--- a/lib/backends/repeater.cc
+++ b/lib/backends/repeater.cc
@@ -78,15 +78,25 @@ void Repeater::flush_stats(const Ledger& ledger, int flusher_id) {
          ++timer_key_value_pair_itr) {
       std::string key = timer_key_value_pair_itr->first;
       std::string out = "";
+      int out_limit = 20
+      int out_counter = 0
       if (key.length() > 0) {
         std::vector<double> values(timer_key_value_pair_itr->second);
         for (auto value_itr = values.cbegin();
-          value_itr != values.cend();
-          ++value_itr) {
+            value_itr != values.cend();
+            ++value_itr) {
+          out_counter++;
           std::string value = std::to_string(static_cast<long double>(*value_itr));
           out += key + ":" + value + "|ms\n";
+          if (out_counter >= out_limit) {
+            this->send(out);
+            out = "";
+            out_counter = 0;
+          }
         }
-        this->send(out);
+        if(! out.empty()) {
+            this->send(out);
+        }
       }
     }
   } else {

--- a/lib/backends/repeater.cc
+++ b/lib/backends/repeater.cc
@@ -76,15 +76,18 @@ void Repeater::flush_stats(const Ledger& ledger, int flusher_id) {
     for (auto timer_key_value_pair_itr = ledger.timers.cbegin();
          timer_key_value_pair_itr != ledger.timers.cend();
          ++timer_key_value_pair_itr) {
+
       std::string key = timer_key_value_pair_itr->first;
       std::string out = "";
-      int out_limit = 20
-      int out_counter = 0
+      int out_limit = 20;
+      int out_counter = 0;
+
       if (key.length() > 0) {
         std::vector<double> values(timer_key_value_pair_itr->second);
         for (auto value_itr = values.cbegin();
             value_itr != values.cend();
             ++value_itr) {
+
           out_counter++;
           std::string value = std::to_string(static_cast<long double>(*value_itr));
           out += key + ":" + value + "|ms\n";
@@ -93,6 +96,7 @@ void Repeater::flush_stats(const Ledger& ledger, int flusher_id) {
             out = "";
             out_counter = 0;
           }
+          
         }
         if(! out.empty()) {
             this->send(out);


### PR DESCRIPTION
Timers being sent by the repeater were being lost because the data block was too large.  This will send the timers in batches of 20 per timer key.