### PR TITLE
Relay Statistics

### DIFF
--- a/include/statsdcc/backends/repeater.h
+++ b/include/statsdcc/backends/repeater.h
@@ -55,6 +55,9 @@ class Repeater: public statsdcc::backends::Backend {
 
   // destinations
   std::vector<sockaddr_in> destinations;
+
+  // prefix for stats
+  std::string prefix_stats;
 };
 
 }  // namespace backends

--- a/lib/backends/repeater.cc
+++ b/lib/backends/repeater.cc
@@ -153,12 +153,12 @@ void Repeater::flush_stats(const Ledger& ledger, int flusher_id) {
   this->prefix_stats = ::config->name;
 
   // Statsd metrics
-  if (ledger.statsd_metrics("metrics_processed") != ledger.statsd_metrics.end()) {
+  if (ledger.statsd_metrics.find("metrics_processed") != ledger.statsd_metrics.end()) {
       this->send(
         this->prefix_stats + ".metrics_processed:" +
         std::to_string(static_cast<long long int>(ledger.statsd_metrics["metrics_processed"])) + "|c");
   }
-  if (ledger.statsd_metrics("processing_time") != ledger.statsd_metrics.end()) {
+  if (ledger.statsd_metrics.find("processing_time") != ledger.statsd_metrics.end()) {
       this->send(
         this->prefix_stats + ".processing_time:" +
         std::to_string(static_cast<long long int>(ledger.statsd_metrics["processing_time"])) + "|ms");

--- a/lib/backends/repeater.cc
+++ b/lib/backends/repeater.cc
@@ -153,12 +153,16 @@ void Repeater::flush_stats(const Ledger& ledger, int flusher_id) {
   this->prefix_stats = ::config->name;
 
   // Statsd metrics
-  this->send(
-    this->prefix_stats + ".metrics_processed:" +
-    std::to_string(static_cast<long long int>(ledger.statsd_metrics["metrics_processed"])) + "|c")
-  this->send(
-    this->prefix_stats + ".processing_time:" +
-    std::to_string(static_cast<long long int>(ledger.statsd_metrics["processing_time"])) + "|ms")
+  if (ledger.statsd_metrics("metrics_processed") != ledger.statsd_metrics.end()) {
+      this->send(
+        this->prefix_stats + ".metrics_processed:" +
+        std::to_string(static_cast<long long int>(ledger.statsd_metrics["metrics_processed"])) + "|c");
+  }
+  if (ledger.statsd_metrics("processing_time") != ledger.statsd_metrics.end()) {
+      this->send(
+        this->prefix_stats + ".processing_time:" +
+        std::to_string(static_cast<long long int>(ledger.statsd_metrics["processing_time"])) + "|ms");
+    }
 
 }
 

--- a/lib/backends/repeater.cc
+++ b/lib/backends/repeater.cc
@@ -153,8 +153,12 @@ void Repeater::flush_stats(const Ledger& ledger, int flusher_id) {
   this->prefix_stats = ::config->name;
 
   // Statsd metrics
-  this->send(this->prefix_stats + '.metrics_processed:' + ledger.statsd_metrics['metrics_processed'] + "|c")
-  this->send(this->prefix_stats + '.processing_time:' + ledger.statsd_metrics['processing_time'] + "|ms")
+  this->send(
+    this->prefix_stats + ".metrics_processed:" +
+    std::to_string(static_cast<long long int>(ledger.statsd_metrics['metrics_processed'])) + "|c")
+  this->send(
+    this->prefix_stats + ".processing_time:" +
+    std::to_string(static_cast<long long int>(ledger.statsd_metrics['processing_time'])) + "|ms")
 
 }
 

--- a/lib/backends/repeater.cc
+++ b/lib/backends/repeater.cc
@@ -154,12 +154,28 @@ void Repeater::flush_stats(const Ledger& ledger, int flusher_id) {
 
   // Statsd metrics
   if (ledger.statsd_metrics.find("metrics_processed") != ledger.statsd_metrics.end()) {
-    std::string processed_val = std::to_string(static_cast<long long int>(ledger.statsd_metrics["metrics_processed"]));
+    std::string processed_val =
+        std::to_string(static_cast<long long int>(ledger.statsd_metrics.find("metrics_processed")));
     this->send(this->prefix_stats + ".metrics_processed:" + processed_val + "|c");
   }
   if (ledger.statsd_metrics.find("processing_time") != ledger.statsd_metrics.end()) {
-    std::string time_val = std::to_string(static_cast<long long int>(ledger.statsd_metrics["processing_time"]));
+    std::string time_val =
+        std::to_string(static_cast<long long int>(ledger.statsd_metrics.find("processing_time")));
     this->send(this->prefix_stats + ".processing_time:" + time_val + "|ms");
+  }
+
+  for (auto statsd_metric_itr = ledger.statsd_metrics.cbegin();
+      statsd_metric_itr != ledger.statsd_metrics.cend();
+      ++statsd_metric_itr) {
+    std::string key = this->prefix_stats + '.' + statsd_metric_itr->first;
+
+    std::string value = std::to_string(
+      static_cast<long long int>(statsd_metric_itr->second));
+
+    stat_strings[this->hashring->get(key)] +=
+      key + " "
+          + value
+          + ts_suffix;
   }
 
 }

--- a/lib/backends/repeater.cc
+++ b/lib/backends/repeater.cc
@@ -153,14 +153,16 @@ void Repeater::flush_stats(const Ledger& ledger, int flusher_id) {
   this->prefix_stats = ::config->name;
 
   // Statsd metrics
-  if (ledger.statsd_metrics.find("metrics_processed") != ledger.statsd_metrics.end()) {
+  metrics_processed = ledger.statsd_metrics.find("metrics_processed")
+  if (metrics_processed != ledger.statsd_metrics.end()) {
     std::string processed_val =
-        std::to_string(static_cast<long long int>(ledger.statsd_metrics.find("metrics_processed")));
+        std::to_string(static_cast<long long int>(metrics_processed->second));
     this->send(this->prefix_stats + ".metrics_processed:" + processed_val + "|c");
   }
-  if (ledger.statsd_metrics.find("processing_time") != ledger.statsd_metrics.end()) {
+  processing_time = ledger.statsd_metrics.find("processing_time")
+  if (processing_time != ledger.statsd_metrics.end()) {
     std::string time_val =
-        std::to_string(static_cast<long long int>(ledger.statsd_metrics.find("processing_time")));
+        std::to_string(static_cast<long long int>(processing_time->second));
     this->send(this->prefix_stats + ".processing_time:" + time_val + "|ms");
   }
 

--- a/lib/backends/repeater.cc
+++ b/lib/backends/repeater.cc
@@ -148,6 +148,14 @@ void Repeater::flush_stats(const Ledger& ledger, int flusher_id) {
            std::to_string(static_cast<long long int>(value.size())) + "|s");
 
   }
+
+  // prefix for stats
+  this->prefix_stats = ::config->name;
+
+  // Statsd metrics
+  this->send(this->prefix_stats + '.metrics_processed:' + ledger.statsd_metrics['metrics_processed'] + "|c")
+  this->send(this->prefix_stats + '.processing_time:' + ledger.statsd_metrics['processing_time'] + "|ms")
+
 }
 
 }  // namespace backends

--- a/lib/backends/repeater.cc
+++ b/lib/backends/repeater.cc
@@ -155,10 +155,10 @@ void Repeater::flush_stats(const Ledger& ledger, int flusher_id) {
   // Statsd metrics
   this->send(
     this->prefix_stats + ".metrics_processed:" +
-    std::to_string(static_cast<long long int>(ledger.statsd_metrics['metrics_processed'])) + "|c")
+    std::to_string(static_cast<long long int>(ledger.statsd_metrics["metrics_processed"])) + "|c")
   this->send(
     this->prefix_stats + ".processing_time:" +
-    std::to_string(static_cast<long long int>(ledger.statsd_metrics['processing_time'])) + "|ms")
+    std::to_string(static_cast<long long int>(ledger.statsd_metrics["processing_time"])) + "|ms")
 
 }
 

--- a/lib/backends/repeater.cc
+++ b/lib/backends/repeater.cc
@@ -154,11 +154,11 @@ void Repeater::flush_stats(const Ledger& ledger, int flusher_id) {
 
   // Statsd metrics
   if (ledger.statsd_metrics.find("metrics_processed") != ledger.statsd_metrics.end()) {
-    std::string processed_val = std::to_string(static_cast<long long int>(ledger.statsd_metrics["metrics_processed"]))
+    std::string processed_val = std::to_string(static_cast<long long int>(ledger.statsd_metrics["metrics_processed"]));
     this->send(this->prefix_stats + ".metrics_processed:" + processed_val + "|c");
   }
   if (ledger.statsd_metrics.find("processing_time") != ledger.statsd_metrics.end()) {
-    std::string time_val = std::to_string(static_cast<long long int>(ledger.statsd_metrics["processing_time"]))
+    std::string time_val = std::to_string(static_cast<long long int>(ledger.statsd_metrics["processing_time"]));
     this->send(this->prefix_stats + ".processing_time:" + time_val + "|ms");
   }
 

--- a/lib/backends/repeater.cc
+++ b/lib/backends/repeater.cc
@@ -153,13 +153,13 @@ void Repeater::flush_stats(const Ledger& ledger, int flusher_id) {
   this->prefix_stats = ::config->name;
 
   // Statsd metrics
-  metrics_processed = ledger.statsd_metrics.find("metrics_processed")
+  auto metrics_processed = ledger.statsd_metrics.find("metrics_processed");
   if (metrics_processed != ledger.statsd_metrics.end()) {
     std::string processed_val =
         std::to_string(static_cast<long long int>(metrics_processed->second));
     this->send(this->prefix_stats + ".metrics_processed:" + processed_val + "|c");
   }
-  processing_time = ledger.statsd_metrics.find("processing_time")
+  auto processing_time = ledger.statsd_metrics.find("processing_time");
   if (processing_time != ledger.statsd_metrics.end()) {
     std::string time_val =
         std::to_string(static_cast<long long int>(processing_time->second));

--- a/lib/backends/repeater.cc
+++ b/lib/backends/repeater.cc
@@ -154,15 +154,13 @@ void Repeater::flush_stats(const Ledger& ledger, int flusher_id) {
 
   // Statsd metrics
   if (ledger.statsd_metrics.find("metrics_processed") != ledger.statsd_metrics.end()) {
-      this->send(
-        this->prefix_stats + ".metrics_processed:" +
-        std::to_string(static_cast<long long int>(ledger.statsd_metrics["metrics_processed"])) + "|c");
+    std::string processed_val = std::to_string(static_cast<long long int>(ledger.statsd_metrics["metrics_processed"]))
+    this->send(this->prefix_stats + ".metrics_processed:" + processed_val + "|c");
   }
   if (ledger.statsd_metrics.find("processing_time") != ledger.statsd_metrics.end()) {
-      this->send(
-        this->prefix_stats + ".processing_time:" +
-        std::to_string(static_cast<long long int>(ledger.statsd_metrics["processing_time"])) + "|ms");
-    }
+    std::string time_val = std::to_string(static_cast<long long int>(ledger.statsd_metrics["processing_time"]))
+    this->send(this->prefix_stats + ".processing_time:" + time_val + "|ms");
+  }
 
 }
 

--- a/lib/backends/repeater.cc
+++ b/lib/backends/repeater.cc
@@ -166,20 +166,6 @@ void Repeater::flush_stats(const Ledger& ledger, int flusher_id) {
     this->send(this->prefix_stats + ".processing_time:" + time_val + "|ms");
   }
 
-  for (auto statsd_metric_itr = ledger.statsd_metrics.cbegin();
-      statsd_metric_itr != ledger.statsd_metrics.cend();
-      ++statsd_metric_itr) {
-    std::string key = this->prefix_stats + '.' + statsd_metric_itr->first;
-
-    std::string value = std::to_string(
-      static_cast<long long int>(statsd_metric_itr->second));
-
-    stat_strings[this->hashring->get(key)] +=
-      key + " "
-          + value
-          + ts_suffix;
-  }
-
 }
 
 }  // namespace backends


### PR DESCRIPTION
When we switched over to statsdcc as a relay we lost metrics on what is being sent by the daemomsets.  This re-introduces those metrics to be sent by the relay.